### PR TITLE
Adjust Pokemon projectile spawn position

### DIFF
--- a/Content/Projectiles/PokemonPet.cs
+++ b/Content/Projectiles/PokemonPet.cs
@@ -106,7 +106,7 @@ public class PokemonPet(ushort id, DatabaseV2.PokemonSchema schema) : ModProject
         // Move ahead of player
         var direction = Main.player[Projectile.owner].direction;
         _customSpriteDirection = direction;
-        Projectile.position.X += direction * 40;
+        Projectile.position.X += direction * (MathF.Abs(Main.player[Projectile.owner].velocity.X) < 1.5f ? 40 : -30);
 
         var dust = ModContent.DustType<SummonCloud>();
         var mainPosition = new Vector2(Projectile.position.X - Projectile.width / 2f,


### PR DESCRIPTION
- Spawn Pokemon projectile behind player if their horizontal velocity is above 1.5 (e.g. walking)