### PR TITLE
Fix duplication bug with Poke Ball tiles

### DIFF
--- a/Content/Items/PokeBalls/BasePkballTile.cs
+++ b/Content/Items/PokeBalls/BasePkballTile.cs
@@ -177,8 +177,11 @@ public class BasePkballEntity : ModTileEntity
             }
             else
                 Item.stack++;
-
-            player.HeldItem.stack -= 1;
+            
+            if (Main.mouseItem.type == Item.type)
+                Main.mouseItem.stack--;
+            else if (player.HeldItem.type == Item.type)
+                player.HeldItem.stack--;
             return true;
         }
 


### PR DESCRIPTION
- Fix Poke Ball tiles always trying to decrement player.HeldItem on interact rather than using Main.mouseItem when necessary