### PR TITLE
PC active pokemon + sound polish

### DIFF
--- a/Content/GUI/InventoryParty.cs
+++ b/Content/GUI/InventoryParty.cs
@@ -145,6 +145,11 @@ public class InventoryParty : SmartUIState
             foreach (var slot in CustomSlots)
                 slot.Color = Color.Transparent;
         }
+        
+        SoundEngine.PlaySound(new SoundStyle("Terramon/Sounds/ls_pc_off")
+        {
+            Volume = 0.54f
+        });
     }
 
     private void KillAllTweens()
@@ -386,7 +391,10 @@ internal sealed class CustomPartyItemSlot : UIImage
                 if (!_pretendToBeEmptyState) return;
                 var modPlayer = TerramonPlayer.LocalPlayer;
                 modPlayer.Party[Index] = null;
-                modPlayer.ActiveSlot = -1;
+                if (modPlayer.ActiveSlot == Index)
+                    modPlayer.ActiveSlot = -1;
+                else
+                    modPlayer.ActiveSlot--;
                 // Cascade the Pokémon to the left
                 for (var i = Index; i < modPlayer.Party.Length - 1; i++)
                     modPlayer.Party[i] = modPlayer.Party[i + 1];
@@ -401,6 +409,10 @@ internal sealed class CustomPartyItemSlot : UIImage
                     TooltipOverlay.ClearHeldPokemon(place: false); // Hack, don't know why but this is needed :D
                 TerramonPlayer.LocalPlayer.Party[Index] = heldPokemon;
                 SetData(heldPokemon);
+                
+                var modPlayer = TerramonPlayer.LocalPlayer;
+                if (modPlayer.ActiveSlot == Index)
+                    modPlayer.ActiveSlot = -1;
             }
             else
             {

--- a/Content/Tiles/Interactive/PCTile.cs
+++ b/Content/Tiles/Interactive/PCTile.cs
@@ -114,9 +114,9 @@ public abstract class PCTile : ModTile
         // Play the appropriate sound for the action
         if (differentPc)
             SoundEngine.PlaySound(SoundID.MenuTick);
-        else
+        else if (te.PoweredOn)
             SoundEngine.PlaySound(
-                new SoundStyle(te.PoweredOn ? "Terramon/Sounds/ls_pc_on" : "Terramon/Sounds/ls_pc_off")
+                new SoundStyle("Terramon/Sounds/ls_pc_on")
                 {
                     Volume = 0.54f
                 });


### PR DESCRIPTION
- Decrement active slot when a Pokemon is removed from the PC if the active Pokemon wasn't removed
- Set active slot to -1 if the active pokemon is removed from the party or swapped with a different one
- Move PlaySound for ls_pc_off to ExitPCMode so it plays when escape key is used to exit the PC interface (previously only played when tile was right-clicked)