### PR TITLE
Fix server crash

### DIFF
--- a/Content/GUI/UILinkManager.cs
+++ b/Content/GUI/UILinkManager.cs
@@ -11,12 +11,9 @@ public class UILinkManager : ILoadable
 {
     //reference position for first slot in the row (default Pokédex position)
     private static readonly Vector2 FirstSlotPos = new(51, 291);
-    
+    public bool IsLoadingEnabled(Mod mod) => !Main.dedServ;
     public void Load(Mod mod)
     {
-        if (Main.dedServ)
-            return;
-
         SetupPartyUIPage();
         SetupPCUIPage();
         SetupHubUIPage();
@@ -37,9 +34,6 @@ public class UILinkManager : ILoadable
 
     public void Unload()
     {
-        if (Main.dedServ)
-            return;
-
         RemovePage(TerramonPageID.Party);
         RemovePage(TerramonPageID.PC);
         RemovePage(TerramonPageID.HubUI);

--- a/Content/GUI/UILinkManager.cs
+++ b/Content/GUI/UILinkManager.cs
@@ -14,6 +14,9 @@ public class UILinkManager : ILoadable
     
     public void Load(Mod mod)
     {
+        if (Main.dedServ)
+            return;
+
         SetupPartyUIPage();
         SetupPCUIPage();
         SetupHubUIPage();
@@ -34,6 +37,9 @@ public class UILinkManager : ILoadable
 
     public void Unload()
     {
+        if (Main.dedServ)
+            return;
+
         RemovePage(TerramonPageID.Party);
         RemovePage(TerramonPageID.PC);
         RemovePage(TerramonPageID.HubUI);


### PR DESCRIPTION
Fixes server crash caused by gamepad support added in the latest version of the mod.
Crash was caused because the ILoadable for gamepad support tries to access a dictionary which is not initialized on the server.