### PR TITLE
improve StartBattleEffects usage

### DIFF
--- a/Terramon/Content/NPCs/PokemonNPC.cs
+++ b/Terramon/Content/NPCs/PokemonNPC.cs
@@ -100,7 +100,7 @@ public class PokemonNPC(ushort id, DatabaseV2.PokemonSchema schema) : ModNPC, IP
     public Entity SyncedEntity => NPC;
     public string BattleName => "Wild " + Data.DisplayName;
     public PokemonData[] GetBattleTeam() => [Data];
-    public void StartBattleEffects()
+    public void StartBattleEffects(bool before)
     {
         // Turn towards the player and disable hover behaviour
         NPC.spriteDirection = NPC.direction = BattleClient.Foe.SyncedEntity.position.X > NPC.position.X ? 1 : -1;

--- a/Terramon/Core/Battling/BattleInstance.cs
+++ b/Terramon/Core/Battling/BattleInstance.cs
@@ -145,13 +145,10 @@ public sealed class BattleInstance
 
         ClientA.State = ClientB.State = ClientBattleState.Ongoing;
 
-        // No this isn't a mistake, but because Terraria isn't a quantum program,
-        // we can't make it so that both sides run after the other one at the same time
-        // unless we do this
-        ClientA.Provider.StartBattleEffects();
-        ClientB.Provider.StartBattleEffects();
-        ClientA.Provider.StartBattleEffects();
-        ClientB.Provider.StartBattleEffects();
+        // Effects
+        ClientA.Provider.StartBattleEffects(before: true);
+        ClientB.Provider.StartBattleEffects(before: false);
+        ClientA.Provider.StartBattleEffects(before: false);
     }
 
     public void Stop()

--- a/Terramon/Core/Battling/IBattleProvider.cs
+++ b/Terramon/Core/Battling/IBattleProvider.cs
@@ -9,7 +9,12 @@ public interface IBattleProvider
     Entity SyncedEntity { get; }
     string BattleName { get; }
     PokemonData[] GetBattleTeam();
-    void StartBattleEffects();
+    /// <summary>
+    ///     Things this <see cref="IBattleProvider"/> should do the moment it starts a battle.
+    ///     Called twice on the server, local, and remote clients. In Singleplayer, called only by <see cref="BattleManager"/>.
+    /// </summary>
+    /// <param name="before">Whether the method is running before the <see cref="Foe"/> has gotten the chance to.</param>
+    void StartBattleEffects(bool before);
     void StopBattleEffects();
     void SetActiveSlot(byte newActive);
     /// <summary>

--- a/Terramon/Core/TerramonPlayer.cs
+++ b/Terramon/Core/TerramonPlayer.cs
@@ -117,9 +117,10 @@ public class TerramonPlayer : ModPlayer, IBattleProvider
     public Entity SyncedEntity => Player;
     public string BattleName => Player.name;
     public PokemonData[] GetBattleTeam() => Party;
-    public void StartBattleEffects()
+    public void StartBattleEffects(bool before)
     {
-        ActivePetProjectile?.ConfrontFoe(_battleClient);
+        if (!before)
+            ActivePetProjectile?.ConfrontFoe(_battleClient);
         if (Player.whoAmI == Main.myPlayer)
         {
             BattleTicks = 0;
@@ -248,16 +249,17 @@ public class TerramonPlayer : ModPlayer, IBattleProvider
 
                 Main.NewText($"{a} started a battle against {b}!", Color.Aqua);
 
+                // If we're in singleplayer, break early so this stuff only runs from BattleManager
+                if (Main.netMode == NetmodeID.SinglePlayer)
+                    break;
+
                 // Set states
                 owner.State = other.State = ClientBattleState.Ongoing;
 
-                // No this isn't a mistake, but because Terraria isn't a quantum program,
-                // we can't make it so that both sides run after the other one at the same time
-                // unless we do this
-                owner.StartBattleEffects();
-                other.StartBattleEffects();
-                owner.StartBattleEffects();
-                other.StartBattleEffects();
+                // Effects
+                owner.StartBattleEffects(before: true);
+                other.StartBattleEffects(before: false);
+                owner.StartBattleEffects(before: false);
                 break;
             case ForfeitStatement f:
 


### PR DESCRIPTION
add `before` param to `IBattleProvider.StartBattleEffects()`
only call it three times as opposed to four times
in singleplayer, don't call it in `TerramonPlayer.Witness()`